### PR TITLE
allowing for `itemLayout` persistence

### DIFF
--- a/src/lib/components/DashGridLayout.react.js
+++ b/src/lib/components/DashGridLayout.react.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, createRef, useLayoutEffect, forwardRef, memo } from 'react';
 import PropTypes from 'prop-types';
 import { Responsive, WidthProvider } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
@@ -10,27 +10,23 @@ import _ from 'lodash'
 // eslint-disable-next-line new-cap
 const ResponsiveReactGridLayout = WidthProvider(Responsive);
 
-const DashGridLayout = (props) => {
-    const initializeLayout = () => {
-        return props.children.map((child, i) => ({
-            i: i.toString(),
-            // eslint-disable-next-line no-magic-numbers
-            x: i * 2 % 12,
-            // eslint-disable-next-line no-magic-numbers
-            y: Math.floor(i / 6) * 2,
-            w: 2,
-            h: 2,
-            content: child,
-        }));
-    };
+const DashGridLayout = ({ setProps, ...props }) => {
 
-    const [items, setItems] = useState([]);
+
+    const [layoutItems, setItems] = useState([]);
     const [newCounter, setNewCounter] = useState(0);
     const [currentLayout, setCurrentLayout] = useState([]);
     const [resizing, setResizing] = useState(false)
     const [breakpointData, setBreakpointData] = useState({});
     const [breakpoints, setBreakpoints] = useState({lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0})
     const gridLayoutRef = useRef(null)
+    const [layoutMapped, setLayoutMapped] = useState([])
+    const [init, setInit] = useState(false)
+    const layoutItemsRef = useRef([])
+    const ref = useRef();
+    const systemUpdateItems = useRef(null)
+    const setPropsRef = useRef(null)
+    const updateDashLayout = useRef(null)
 
     const findCurrentBreakpoint = (init = false) => {
         const currentWidth = gridLayoutRef.current.clientWidth;
@@ -55,20 +51,69 @@ const DashGridLayout = (props) => {
         return currentBreakpoint
     }
 
+    const convertPropsToLayout = (items) => {
+        const newItems = [...items].map((item, i) => {
+                return {...{
+                        i: item.key,
+                        // eslint-disable-next-line no-magic-numbers
+                        x: i * 2 % 12,
+                        // eslint-disable-next-line no-magic-numbers
+                        y: Math.floor(i / 6) * 2,
+                        w: 2,
+                        h: 2,
+                        content: item,
+                    }, ...props.itemLayout.filter((i) => i.i == item.key)[0]
+
+                }
+        })
+        return newItems
+    }
+
     // initial call
     useEffect(() => {
-        setCurrentLayout(props.currentLayout || items.map(({ i, x, y, w, h }) => ({ i, x, y, w, h })))
-        setItems(props.items || initializeLayout())
-        setNewCounter(props.children.length)
+        setPropsRef.current = _.debounce((props) => {
+            setProps(props)
+        }, 50)
+        updateDashLayout.current = _.debounce((layoutItems) => {
+            const propsToSet = {itemCount: layoutItems.length}
+            if (!_.isEmpty(layoutItems)) {
+                const newLayoutItems = layoutItems.map((item) => {
+                    return _.omit(item, ['content'])
+                })
+                if (!_.isEqual(newLayoutItems, props.itemLayout)) {
+                    propsToSet['itemLayout'] = newLayoutItems
+                    systemUpdateItems.current = true
+                }
+                layoutItemsRef.current = newLayoutItems
+            }
+            setPropsRef.current(propsToSet);
+        }, 50)
+        setCurrentLayout(props.currentLayout || layoutItems.map(({ i, x, y, w, h }) => ({ i, x, y, w, h })))
+        const newItems = convertPropsToLayout(props.items)
+        setItems(newItems)
+        setNewCounter(props.items.length)
         // get initial screen size
         setBreakpointData({newBreakpoint: findCurrentBreakpoint(true)})
+        setInit(true)
     }, [])
 
     useEffect(() => {
-        if (props.setProps) {
-            props.setProps({ itemCount: items.length});
+        if (updateDashLayout.current) {
+            updateDashLayout.current(layoutItems)
         }
-    }, [items]);
+    }, [layoutItems]);
+
+    const updateItemsFromPropsDebounced = _.debounce(() => {
+        if (!_.isEqual(layoutItemsRef, props.items)) {
+            setItems(convertPropsToLayout(props.items));
+        }
+    }, 5);
+
+    useEffect(() => {
+        if (init) {
+            updateItemsFromPropsDebounced()
+        }
+    }, [props.items, props.itemLayout])
 
     useEffect(() => {
         if (props.addItem) {
@@ -77,22 +122,22 @@ const DashGridLayout = (props) => {
         }
     }, [props.addItem]);
 
-    const onLayoutChange = _.debounce((layout, allLayouts) => {
+    const onLayoutChange = _.debounce((layout) => {
         if (findCurrentBreakpoint() == 'lg') {
-            const newItems = items.map((item) => {
+            const newItems = [...layoutItems].map((item) => {
                 const newItem = layout.filter(i => i.i === item.i)[0]
                 return {...item, ...newItem}
             })
-            setItems(newItems)
+            setTimeout(() => setItems(newItems), 1)
         }
-        if (props.setProps) {
-            props.setProps({ currentLayout: layout });
+        if (setProps.current) {
+            setProps.current({ currentLayout: layout });
         }
     }, 5)
 
     const onBreakpointChange = _.debounce((newBreakpoint, newCols) => {
         setBreakpointData({newBreakpoint, newCols})
-        props.setProps({breakpointData: {newBreakpoint, newCols}})
+        setProps({breakpointData: {newBreakpoint, newCols}})
     }, 5)
 
     const onAddItem = () => {
@@ -105,12 +150,12 @@ const DashGridLayout = (props) => {
             h: 2,
             content: props.newItemTemplate || <div>New Item</div>,
         };
-        const newItems = [...items, newItem];
+        const newItems = [...layoutItems, newItem];
         setItems(newItems);
         setNewCounter(newCounter + 1);
 
-        if (props.setProps) {
-            props.setProps({addItem: false });
+        if (setProps) {
+            setProps({addItem: false });
         }
     };
 
@@ -134,7 +179,7 @@ const DashGridLayout = (props) => {
         };
 
         let content = el.content;
-        if (content.type === DraggableWrapper) {
+        if (_.get(content, ['type']) === DraggableWrapper) {
             content = React.cloneElement(content, {
                 handleBackground: content.props.handleBackground,
                 handleColor: content.props.handleColor,
@@ -162,10 +207,10 @@ const DashGridLayout = (props) => {
                 draggableHandle=".react-grid-dragHandle"
                 isResizable={props.showResizeHandles}
                 onBreakpointChange={onBreakpointChange}
-                {...props}
+                {..._.omit(props, ['items'])}
                 breakpoints={breakpoints}
             >
-                {items.map(createElement)}
+                {layoutItems.map(createElement)}
             </ResponsiveReactGridLayout>
         </div>
     );
@@ -180,12 +225,15 @@ DashGridLayout.defaultProps = {
     showRemoveButton: true,
     showResizeHandles: true,
     currentLayout: [],
-    breakpoints: {lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0}
+    breakpoints: {lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0},
+    items: [],
+    itemLayout: [],
+    persisted_props: ['items', 'itemLayout'],
+    persistence_type: 'local',
 };
 
 DashGridLayout.propTypes = {
     id: PropTypes.string,
-    children: PropTypes.node,
     newItemTemplate: PropTypes.node,
     className: PropTypes.string,
     rowHeight: PropTypes.number,
@@ -196,6 +244,17 @@ DashGridLayout.propTypes = {
     compactType: PropTypes.oneOf(['vertical', 'horizontal', null]),
     showRemoveButton: PropTypes.bool,
     showResizeHandles: PropTypes.bool,
+    persistence: PropTypes.bool,
+    persisted_props: PropTypes.array,
+    persistence_type: PropTypes.oneOf(['local', 'memory', 'session']),
+    items: PropTypes.arrayOf(PropTypes.node),
+    itemLayout: PropTypes.arrayOf(PropTypes.shape({
+        i: PropTypes.string,
+        x: PropTypes.number,
+        y: PropTypes.number,
+        w: PropTypes.number,
+        h: PropTypes.number,
+    })),
     currentLayout: PropTypes.arrayOf(PropTypes.shape({
         i: PropTypes.string,
         x: PropTypes.number,

--- a/src/lib/components/DashGridLayout.react.js
+++ b/src/lib/components/DashGridLayout.react.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, createRef, useLayoutEffect, forwardRef, memo } from 'react';
+import React, { useState, useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
 import { Responsive, WidthProvider } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
@@ -12,18 +12,14 @@ const ResponsiveReactGridLayout = WidthProvider(Responsive);
 
 const DashGridLayout = ({ setProps, ...props }) => {
 
-
     const [layoutItems, setItems] = useState([]);
     const [newCounter, setNewCounter] = useState(0);
     const [currentLayout, setCurrentLayout] = useState([]);
-    const [resizing, setResizing] = useState(false)
     const [breakpointData, setBreakpointData] = useState({});
     const [breakpoints, setBreakpoints] = useState({lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0})
     const gridLayoutRef = useRef(null)
-    const [layoutMapped, setLayoutMapped] = useState([])
     const [init, setInit] = useState(false)
     const layoutItemsRef = useRef([])
-    const ref = useRef();
     const systemUpdateItems = useRef(null)
     const setPropsRef = useRef(null)
     const updateDashLayout = useRef(null)
@@ -31,7 +27,8 @@ const DashGridLayout = ({ setProps, ...props }) => {
     const findCurrentBreakpoint = (init = false) => {
         const currentWidth = gridLayoutRef.current.clientWidth;
         if (init) {
-            let breakpoints = {...breakpoints, ...props.breakpoints}
+            // eslint-disable-next-line no-use-before-define
+            const breakpoints = {...breakpoints, ...props.breakpoints}
             setBreakpoints(breakpoints)
         }
         let currentBreakpoint = null;
@@ -62,7 +59,7 @@ const DashGridLayout = ({ setProps, ...props }) => {
                         w: 2,
                         h: 2,
                         content: item,
-                    }, ...props.itemLayout.filter((i) => i.i == item.key)[0]
+                    }, ...props.itemLayout.filter((i) => i.i === item.key)[0]
 
                 }
         })
@@ -73,6 +70,7 @@ const DashGridLayout = ({ setProps, ...props }) => {
     useEffect(() => {
         setPropsRef.current = _.debounce((props) => {
             setProps(props)
+            // eslint-disable-next-line no-magic-numbers
         }, 50)
         updateDashLayout.current = _.debounce((layoutItems) => {
             const propsToSet = {itemCount: layoutItems.length}
@@ -81,12 +79,13 @@ const DashGridLayout = ({ setProps, ...props }) => {
                     return _.omit(item, ['content'])
                 })
                 if (!_.isEqual(newLayoutItems, props.itemLayout)) {
-                    propsToSet['itemLayout'] = newLayoutItems
+                    propsToSet.itemLayout = newLayoutItems
                     systemUpdateItems.current = true
                 }
                 layoutItemsRef.current = newLayoutItems
             }
             setPropsRef.current(propsToSet);
+            // eslint-disable-next-line no-magic-numbers
         }, 50)
         setCurrentLayout(props.currentLayout || layoutItems.map(({ i, x, y, w, h }) => ({ i, x, y, w, h })))
         const newItems = convertPropsToLayout(props.items)
@@ -107,6 +106,7 @@ const DashGridLayout = ({ setProps, ...props }) => {
         if (!_.isEqual(layoutItemsRef, props.items)) {
             setItems(convertPropsToLayout(props.items));
         }
+        // eslint-disable-next-line no-magic-numbers
     }, 5);
 
     useEffect(() => {
@@ -123,7 +123,7 @@ const DashGridLayout = ({ setProps, ...props }) => {
     }, [props.addItem]);
 
     const onLayoutChange = _.debounce((layout) => {
-        if (findCurrentBreakpoint() == 'lg') {
+        if (findCurrentBreakpoint() === 'lg') {
             const newItems = [...layoutItems].map((item) => {
                 const newItem = layout.filter(i => i.i === item.i)[0]
                 return {...item, ...newItem}
@@ -133,11 +133,13 @@ const DashGridLayout = ({ setProps, ...props }) => {
         if (setProps.current) {
             setProps.current({ currentLayout: layout });
         }
+        // eslint-disable-next-line no-magic-numbers
     }, 5)
 
     const onBreakpointChange = _.debounce((newBreakpoint, newCols) => {
         setBreakpointData({newBreakpoint, newCols})
         setProps({breakpointData: {newBreakpoint, newCols}})
+        // eslint-disable-next-line no-magic-numbers
     }, 5)
 
     const onAddItem = () => {
@@ -148,7 +150,6 @@ const DashGridLayout = ({ setProps, ...props }) => {
             y: 0,
             w: 2,
             h: 2,
-            content: props.newItemTemplate || <div>New Item</div>,
         };
         const newItems = [...layoutItems, newItem];
         setItems(newItems);
@@ -234,7 +235,6 @@ DashGridLayout.defaultProps = {
 
 DashGridLayout.propTypes = {
     id: PropTypes.string,
-    newItemTemplate: PropTypes.node,
     className: PropTypes.string,
     rowHeight: PropTypes.number,
     cols: PropTypes.object,

--- a/usage.py
+++ b/usage.py
@@ -7,6 +7,8 @@ import dash_mantine_components as dmc
 from dash_iconify import DashIconify
 from datetime import datetime, date
 import json
+import random
+import string
 
 dash._dash_renderer._set_react_version("18.2.0")
 
@@ -15,14 +17,14 @@ app = Dash(__name__)
 # Sample data for the graph
 df = px.data.iris()
 
-newComp = dgl.DraggableWrapper(
-                        dcc.Graph(
-                            figure=px.scatter(
-                                df, x="petal_width", y="petal_length", color="species"
-                            ),
-                            style={"height": "100%"},
-                        )
-                    )
+# Create a Random String ID for the new component
+def generate_random_string(length):
+    # Define the characters to choose from
+    characters = string.ascii_letters + string.digits
+    # Generate a random string
+    random_string = ''.join(random.choice(characters) for _ in range(length))
+    return random_string
+
 
 app.layout = dmc.MantineProvider(
     [
@@ -77,6 +79,7 @@ app.layout = dmc.MantineProvider(
                                 ),
                             ],
                             id="draggable-map-1",
+                            handleBackground="rgb(85,85,85) !important;",
                         ),
                         dgl.DraggableWrapper(
                             html.Img(
@@ -121,7 +124,6 @@ app.layout = dmc.MantineProvider(
                             )
                         ),
                     ],
-                    newItemTemplate=newComp,
                     showRemoveButton=False,
                     showResizeHandles=False,
                     rowHeight=150,
@@ -177,6 +179,7 @@ def display_layout(current_layout):
 def add_dynamic_component(n):
     if n:
         items = Patch()
+        new_id = generate_random_string(10)
         items.append(dgl.DraggableWrapper(
                         dcc.Graph(
                             figure=px.scatter(
@@ -184,13 +187,13 @@ def add_dynamic_component(n):
                             ),
                             style={"height": "100%"},
                         ),
-                        id='testing'
+                        id=f'{new_id}'
                     ))
         itemLayout = Patch()
-        itemLayout.append({'i': 'testing', 'w': 4})
+        itemLayout.append({'i': f'{new_id}', 'w': 6})
         return items, itemLayout
     return no_update, no_update
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    app.run_server(debug=True, port=8321)

--- a/usage.py
+++ b/usage.py
@@ -6,6 +6,7 @@ import dash_leaflet as dl
 import dash_mantine_components as dmc
 from dash_iconify import DashIconify
 from datetime import datetime, date
+import json
 
 dash._dash_renderer._set_react_version("18.2.0")
 
@@ -13,6 +14,15 @@ app = Dash(__name__)
 
 # Sample data for the graph
 df = px.data.iris()
+
+newComp = dgl.DraggableWrapper(
+                        dcc.Graph(
+                            figure=px.scatter(
+                                df, x="petal_width", y="petal_length", color="species"
+                            ),
+                            style={"height": "100%"},
+                        )
+                    )
 
 app.layout = dmc.MantineProvider(
     [
@@ -53,7 +63,7 @@ app.layout = dmc.MantineProvider(
                 ),
                 dgl.DashGridLayout(
                     id="grid-layout",
-                    children=[
+                    items=[
                         dgl.DraggableWrapper(
                             children=[
                                 dl.Map(
@@ -111,20 +121,14 @@ app.layout = dmc.MantineProvider(
                             )
                         ),
                     ],
-                    newItemTemplate=dgl.DraggableWrapper(
-                        dcc.Graph(
-                            figure=px.scatter(
-                                df, x="petal_width", y="petal_length", color="species"
-                            ),
-                            style={"height": "100%"},
-                        )
-                    ),
+                    newItemTemplate=newComp,
                     showRemoveButton=False,
                     showResizeHandles=False,
                     rowHeight=150,
                     cols={"lg": 12, "md": 10, "sm": 6, "xs": 4, "xxs": 2},
                     style={"height": "800px"},
                     compactType="horizontal",
+                    persistence=True
                 ),
                 html.Div(id="layout-output"),
                 dcc.Store(id="layout-store"),
@@ -157,26 +161,35 @@ def enter_editable_mode(n_clicks, current_remove, current_resize):
     return not current_remove, not current_resize, "rgba(255, 255, 255, 0.7)"
 
 
-@callback(Output("layout-output", "children"), Input("layout-store", "data"))
+@callback(Output("layout-output", "children"), Input("grid-layout", "items"))
 def display_layout(current_layout):
-    print("Current Layout:", current_layout)  # Debug print
     if current_layout and isinstance(current_layout, list):
-        layout_str = "Displayed as [x, y, w, h]:\n"
-        for i, item in enumerate(current_layout):
-            layout_str += f"{i}: [{item['x']}, {item['y']}, {item['w']}, {item['h']}]\n"
-        return html.Pre(layout_str)
+        return html.Div(json.dumps(current_layout))
     return "No layout data available"
 
 
 @callback(
-    Output("grid-layout", "addItem"),
+    Output("grid-layout", "items"),
+    Output("grid-layout", "itemLayout"),
     Input("add-dynamic-component", "n_clicks"),
     prevent_initial_call=True,
 )
-def add_dynamic_component(n_clicks):
-    if n_clicks is None:
-        raise PreventUpdate
-    return True
+def add_dynamic_component(n):
+    if n:
+        items = Patch()
+        items.append(dgl.DraggableWrapper(
+                        dcc.Graph(
+                            figure=px.scatter(
+                                df, x="petal_width", y="petal_length", color="species"
+                            ),
+                            style={"height": "100%"},
+                        ),
+                        id='testing'
+                    ))
+        itemLayout = Patch()
+        itemLayout.append({'i': 'testing', 'w': 4})
+        return items, itemLayout
+    return no_update, no_update
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
making adjustments to allow persistence with `itemLayout` and now all layouts should be driven from the items instead of `children`.

- `itemLayout` and `items` now link from the `key` or `id` associated with a component
- with persistence on, `itemLayout` will automatically persist any changes made to a layout in large mode, and will be replayed upon reload as long as the matching items are also provided.