### PR TITLE
switching layout trigger from `onLayoutChange`

### DIFF
--- a/src/lib/components/DashGridLayout.react.js
+++ b/src/lib/components/DashGridLayout.react.js
@@ -216,7 +216,8 @@ const DashGridLayout = ({setProps, ...props}) => {
     return (
         <div id={props.id} style={props.style} ref={gridLayoutRef}>
             <ResponsiveReactGridLayout
-                onLayoutChange={onLayoutChange}
+                onDragStop={onLayoutChange}
+                onResizeStop={onLayoutChange}
                 layouts={{lg: currentLayout}}
                 resizeHandles={
                     props.showResizeHandles

--- a/src/lib/components/DashGridLayout.react.js
+++ b/src/lib/components/DashGridLayout.react.js
@@ -229,6 +229,7 @@ const DashGridLayout = ({setProps, ...props}) => {
                 onBreakpointChange={onBreakpointChange}
                 {..._.omit(props, ['items'])}
                 breakpoints={breakpoints}
+                preventCollision={!props.compactType}
             >
                 {layoutItems.map(createElement)}
             </ResponsiveReactGridLayout>


### PR DESCRIPTION
switching layout trigger from `onLayoutChange` to trigger on both `onDragStop` and `onResizeStop` instead

- smooths the interface a little